### PR TITLE
Use scissor region for clear procedures

### DIFF
--- a/aglet.nimble
+++ b/aglet.nimble
@@ -26,7 +26,7 @@ task buildDocs, "rebuilds documentation to the docs/ folder for GitHub Pages":
   echo "-- building docs for aglet.nim"
   selfExec "doc " &
     "--project --index:on -o:docs/ " &
-    "--git.url:https://github.com/liquid600pgm/aglet " &
+    "--git.url:https://github.com/liquidev/aglet " &
     "--git.commit:" & version & " " &
     "src/aglet.nim"
 

--- a/src/aglet/target.nim
+++ b/src/aglet/target.nim
@@ -7,6 +7,8 @@ import gl
 import pixeltypes
 import program_base
 import uniform
+import rect
+import std/options
 
 type
   Target* = object of RootObj
@@ -34,19 +36,38 @@ proc height*(target: Target): int {.inline.} =
   ## Returns the height of the target.
   target.size.y
 
-proc clearColor*(target: Target, color: Rgba32f) {.inline.} =
+proc scissor(target: Target, scissor: Option[Recti] = Recti.none) =
+  if scissor.isSome():
+    let scissor = scissor.get
+    target.gl.scissor(scissor.x, scissor.y, scissor.width, scissor.height)
+  else:
+    target.gl.scissor(0, 0, target.size.x, target.size.y)
+
+proc clearColor*(target: Target, color: Rgba32f, scissor: Option[Recti] = Recti.none) {.inline.} =
   ## Clear the target's color with a solid color.
+  ## 
+  ## Optionally pass in a scissor rect to control the cleared region.
+  ## By default the entire target is cleared.
   target.use()
+  target.scissor(scissor)
   target.gl.clearColor(color.r, color.g, color.b, color.a)
 
-proc clearDepth*(target: Target, depth: float32) {.inline.} =
+proc clearDepth*(target: Target, depth: float32, scissor: Option[Recti] = Recti.none) {.inline.} =
   ## Clear the target's depth buffer with a single value.
+  ##
+  ## Optionally pass in a scissor rect to control the cleared region.
+  ## By default the entire target is cleared.
   target.use()
+  target.scissor(scissor)
   target.gl.clearDepth(depth)
 
-proc clearStencil*(target: Target, stencil: int32) {.inline.} =
+proc clearStencil*(target: Target, stencil: int32, scissor: Option[Recti] = Recti.none) {.inline.} =
   ## Clear the target's stencil buffer with a single value.
+  ##
+  ## Optionally pass in a scissor rect to control the cleared region.
+  ## By default the entire target is cleared.
   target.use()
+  target.scissor(scissor)
   target.gl.clearStencil(stencil.GlInt)
 
 proc draw*[D: Drawable, U: UniformSource](target: Target, program: Program,

--- a/src/aglet/target.nim
+++ b/src/aglet/target.nim
@@ -17,6 +17,12 @@ type
     useImpl*: proc (target: Target, gl: OpenGl) {.nimcall.}
     gl*: OpenGl
 
+  ClearParams = object
+    color*: Option[Rgba32f]
+    depth*: Option[float32]
+    stencil*: Option[int32]
+    scissor*: Option[Recti]
+
   Drawable* = concept x
     x.draw(OpenGl)
 
@@ -36,39 +42,61 @@ proc height*(target: Target): int {.inline.} =
   ## Returns the height of the target.
   target.size.y
 
-proc scissor(target: Target, scissor: Option[Recti] = Recti.none) =
+proc scissor(target: Target, scissor: Option[Recti]) =
   if scissor.isSome():
     let scissor = scissor.get
     target.gl.scissor(scissor.x, scissor.y, scissor.width, scissor.height)
   else:
     target.gl.scissor(0, 0, target.size.x, target.size.y)
 
-proc clearColor*(target: Target, color: Rgba32f, scissor: Option[Recti] = Recti.none) {.inline.} =
-  ## Clear the target's color with a solid color.
-  ## 
-  ## Optionally pass in a scissor rect to control the cleared region.
-  ## By default the entire target is cleared.
-  target.use()
-  target.scissor(scissor)
-  target.gl.clearColor(color.r, color.g, color.b, color.a)
+proc defaultClearParams*(): ClearParams =
+  ClearParams(
+    color: rgba(0.0, 0.0, 0.0, 1.0).some(),
+    depth: some(1.0.float32),
+    stencil: int32.none(),
+    scissor: Recti.none()
+  )
 
-proc clearDepth*(target: Target, depth: float32, scissor: Option[Recti] = Recti.none) {.inline.} =
-  ## Clear the target's depth buffer with a single value.
-  ##
-  ## Optionally pass in a scissor rect to control the cleared region.
-  ## By default the entire target is cleared.
-  target.use()
-  target.scissor(scissor)
-  target.gl.clearDepth(depth)
+proc withColor*(clearParams: ClearParams, color: Rgba32f): ClearParams =
+  ## Modifies the `color` field of ClearParams and returns it.
+  var clearParams = clearParams
+  clearParams.color = color.some()
+  clearParams
 
-proc clearStencil*(target: Target, stencil: int32, scissor: Option[Recti] = Recti.none) {.inline.} =
-  ## Clear the target's stencil buffer with a single value.
-  ##
-  ## Optionally pass in a scissor rect to control the cleared region.
-  ## By default the entire target is cleared.
+proc withDepth*(clearParams: ClearParams, depth: float32): ClearParams =
+  ## Modifies the `depth` field of ClearParams and returns it.
+  var clearParams = clearParams
+  clearParams.depth = depth.some()
+  clearParams
+
+proc withStencil*(clearParams: ClearParams, stencil: int32): ClearParams =
+  ## Modifies the `stencil` field of ClearParams and returns it.
+  var clearParams = clearParams
+  clearParams.stencil = stencil.some()
+  clearParams
+
+proc withScissor*(clearParams: ClearParams, scissor: Recti): ClearParams =
+  ## Modifies the `scissor` field of ClearParams and returns it.
+  var clearParams = clearParams
+  clearParams.scissor = scissor.some()
+  clearParams
+
+proc clear*(target: Target, clearParams: ClearParams) {.inline.} =
+  ## Clears the target depending on the values in the provided `ClearParams`.
   target.use()
-  target.scissor(scissor)
-  target.gl.clearStencil(stencil.GlInt)
+  target.scissor(clearParams.scissor)
+  
+  if clearParams.color.isSome():
+    let color = clearParams.color.get()
+    target.gl.clearColor(color.r, color.g, color.b, color.a)
+
+  if clearParams.depth.isSome():
+    let depth = clearParams.depth.get()
+    target.gl.clearDepth(depth)
+
+  if clearParams.stencil.isSome():
+    let stencil = clearParams.stencil.get()
+    target.gl.clearStencil(stencil.GlInt)
 
 proc draw*[D: Drawable, U: UniformSource](target: Target, program: Program,
                                           arrays: D, uniforms: U,

--- a/src/aglet/window.nim
+++ b/src/aglet/window.nim
@@ -6,7 +6,6 @@
 ## the one implemented in aglet is as simple and lightweight as it can get.
 
 import std/options
-import std/sets
 
 import glm/vec
 

--- a/tests/tcloud.nim
+++ b/tests/tcloud.nim
@@ -251,8 +251,7 @@ while not win.closeRequested:
     aspect = win.width / win.height
     projection = perspective(Fov.float32, aspect, 0.01, 100.0)
 
-  targetA.clearColor(rgba(0.0, 0.0, 0.0, 1.0))
-  targetA.clearDepth(1.0)
+  targetA.clear(defaultClearParams())
   targetA.draw(volumeProgram, mesh, uniforms {
     model: mat4f(),
     view: lookAt(eye = vec3f(0.0, 0.0, CameraRadius),
@@ -271,7 +270,7 @@ while not win.closeRequested:
   let blurStrength = zoom * 41.0
 
   var targetB = blurBufferB.render()
-  targetB.clearColor(rgba(0.0, 0.0, 0.0, 1.0))
+  targetB.clear(defaultClearParams())
   targetB.draw(blurProgram, fullScreen, uniforms {
     source: blurBufferA.sampler(),
     blurDirection: vec2f(1.0, 0.0),
@@ -280,7 +279,7 @@ while not win.closeRequested:
   }, dpDefault)
 
   var frame = win.render()
-  frame.clearColor(rgba(0.0, 0.0, 0.0, 1.0))
+  frame.clear(defaultClearParams())
   frame.draw(blurProgram, fullScreen, uniforms {
     source: blurBufferB.sampler(),
     blurDirection: vec2f(0.0, 1.0),

--- a/tests/tcloud.nim
+++ b/tests/tcloud.nim
@@ -251,7 +251,9 @@ while not win.closeRequested:
     aspect = win.width / win.height
     projection = perspective(Fov.float32, aspect, 0.01, 100.0)
 
-  targetA.clear(defaultClearParams())
+  targetA.clear(clearParams()
+    .withColor(rgba(0.0, 0.0, 0.0, 1.0))
+    .withDepth(1.0))
   targetA.draw(volumeProgram, mesh, uniforms {
     model: mat4f(),
     view: lookAt(eye = vec3f(0.0, 0.0, CameraRadius),
@@ -270,7 +272,7 @@ while not win.closeRequested:
   let blurStrength = zoom * 41.0
 
   var targetB = blurBufferB.render()
-  targetB.clear(defaultClearParams())
+  targetB.clear(clearParams().withColor(rgba(0.0, 0.0, 0.0, 1.0)))
   targetB.draw(blurProgram, fullScreen, uniforms {
     source: blurBufferA.sampler(),
     blurDirection: vec2f(1.0, 0.0),
@@ -279,7 +281,7 @@ while not win.closeRequested:
   }, dpDefault)
 
   var frame = win.render()
-  frame.clear(defaultClearParams())
+  frame.clear(clearParams().withColor(rgba(0.0, 0.0, 0.0, 1.0)))
   frame.draw(blurProgram, fullScreen, uniforms {
     source: blurBufferB.sampler(),
     blurDirection: vec2f(0.0, 1.0),

--- a/tests/tinstancing.nim
+++ b/tests/tinstancing.nim
@@ -80,7 +80,7 @@ let dpDefault = defaultDrawParams().derive:
 
 while not win.closeRequested:
   var frame = win.render()
-  frame.clearColor(rgba(0, 0, 0, 0))
+  frame.clear(defaultClearParams().withColor(rgba(0, 0, 0, 0)))
   frame.draw(prog, circle.instanced(InstanceCount), uniforms {
     model: mat4f()
       .translate(win.width / 2, win.height / 2, 0)

--- a/tests/tinstancing.nim
+++ b/tests/tinstancing.nim
@@ -80,7 +80,7 @@ let dpDefault = defaultDrawParams().derive:
 
 while not win.closeRequested:
   var frame = win.render()
-  frame.clear(defaultClearParams().withColor(rgba(0, 0, 0, 0)))
+  frame.clear(clearParams().withColor(rgba(0, 0, 0, 0)))
   frame.draw(prog, circle.instanced(InstanceCount), uniforms {
     model: mat4f()
       .translate(win.width / 2, win.height / 2, 0)

--- a/tests/ttextures.nim
+++ b/tests/ttextures.nim
@@ -72,7 +72,7 @@ let drawParams = defaultDrawParams()
 
 while not win.closeRequested:
   var target = win.render()
-  target.clear(defaultClearParams())
+  target.clear(clearParams().withColor(rgba(0.0, 0.0, 0.0, 1.0)))
   target.draw(prog, rect, uniforms {
     ?noise: noiseTex.sampler(),
     ?bricks: bricksTex.sampler(magFilter = fmNearest),

--- a/tests/ttextures.nim
+++ b/tests/ttextures.nim
@@ -72,7 +72,7 @@ let drawParams = defaultDrawParams()
 
 while not win.closeRequested:
   var target = win.render()
-  target.clearColor(rgba(0.0, 0.0, 0.0, 1.0))
+  target.clear(defaultClearParams())
   target.draw(prog, rect, uniforms {
     ?noise: noiseTex.sampler(),
     ?bricks: bricksTex.sampler(magFilter = fmNearest),

--- a/tests/ttriangle.nim
+++ b/tests/ttriangle.nim
@@ -65,7 +65,7 @@ let startTime = epochTime()
 while not win.closeRequested:
   var frame = win.render()
 
-  frame.clearColor(rgba(0.0, 0.0, 0.0, 1.0))
+  frame.clear(defaultClearParams())
 
   frame.draw(prog, mesh, uniforms {
     time: float32(epochTime() - startTime),

--- a/tests/ttriangle.nim
+++ b/tests/ttriangle.nim
@@ -65,7 +65,7 @@ let startTime = epochTime()
 while not win.closeRequested:
   var frame = win.render()
 
-  frame.clear(defaultClearParams())
+  frame.clear(clearParams().withColor(rgba(0.0, 0.0, 0.0, 1.0)))
 
   frame.draw(prog, mesh, uniforms {
     time: float32(epochTime() - startTime),

--- a/tests/twindow_glfw.nim
+++ b/tests/twindow_glfw.nim
@@ -10,7 +10,7 @@ var win = agl.newWindowGlfw(800, 600, "GLFW window test",
 
 while not win.closeRequested:
   var frame = win.render()
-  frame.clear(defaultClearParams().withColor(rgba(0.0, 0.0, 1.0, 1.0)))
+  frame.clear(clearParams().withColor(rgba(0.0, 0.0, 1.0, 1.0)))
   frame.finish()
 
   win.pollEvents do (ev: InputEvent):

--- a/tests/twindow_glfw.nim
+++ b/tests/twindow_glfw.nim
@@ -10,7 +10,7 @@ var win = agl.newWindowGlfw(800, 600, "GLFW window test",
 
 while not win.closeRequested:
   var frame = win.render()
-  frame.clearColor(rgba(0.0, 0.0, 1.0, 1.0))
+  frame.clear(defaultClearParams().withColor(rgba(0.0, 0.0, 1.0, 1.0)))
   frame.finish()
 
   win.pollEvents do (ev: InputEvent):


### PR DESCRIPTION
When using draw params with the scissor rect enabled, the next call to `glClear` color is affected as the scissor rect is still active when the draw has ended. This is because `glClear` uses the current scissor rect to determine which pixels to clear.

This results in this funky behavior:

https://user-images.githubusercontent.com/3239951/131235182-a17fb96d-4924-49be-b99c-5ae384f63049.mp4

Setting the scissor rect before clearing fixes this behavior:

https://user-images.githubusercontent.com/3239951/131235209-3cb2437b-57d3-4b9c-b9ad-e679a7a0ef34.mp4

## Proposed Solution
Allow passing custom scissor regions to clear functions and clear the entire target by default.



